### PR TITLE
zram-generator: first attempt at NixOS test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -741,6 +741,7 @@ in {
   zigbee2mqtt = handleTest ./zigbee2mqtt.nix {};
   zoneminder = handleTest ./zoneminder.nix {};
   zookeeper = handleTest ./zookeeper.nix {};
+  zram-generator = handleTest ./zram-generator.nix {};
   zrepl = handleTest ./zrepl.nix {};
   zsh-history = handleTest ./zsh-history.nix {};
 }

--- a/nixos/tests/zram-generator.nix
+++ b/nixos/tests/zram-generator.nix
@@ -1,0 +1,17 @@
+import ./make-test-python.nix {
+  name = "zram-generator";
+
+  nodes.machine = { pkgs, ... }: {
+    environment.etc."systemd/zram-generator.conf".text = ''
+      [zram0]
+      zram-size = ram / 2
+    '';
+    systemd.packages = [ pkgs.zram-generator ];
+  };
+
+  testScript = ''
+    machine.wait_for_unit("systemd-zram-setup@zram0.service")
+    assert "zram0" in machine.succeed("zramctl -n")
+    assert "zram0" in machine.succeed("swapon --show --noheadings")
+  '';
+}


### PR DESCRIPTION
I wrote a NixOS test for the systemd-zram-generator, but it currently failed with
```
× systemd-zram-setup@zram0.service - Create swap on /dev/zram0
     Loaded: loaded (/etc/systemd/system/systemd-zram-setup@.service; static)
    Drop-In: /run/systemd/generator/systemd-zram-setup@zram0.service.d
             └─bindings.conf
     Active: failed (Result: exit-code) since Wed 2023-01-18 14:42:35 UTC; 29s ago
       Docs: man:zram-generator(8)
             man:zram-generator.conf(5)
    Process: 868 ExecStart=/nix/store/qc2cd163y35m4745s4y27lj1qbib9501-zram-generator-1.1.2/lib/systemd/system-generators/zram-generator --setup-device zram0 (code=exited, status=1/FAILURE)
   Main PID: 868 (code=exited, status=1/FAILURE)
         IP: 0B in, 0B out
        CPU: 1ms

Jan 18 14:42:35 machine systemd[1]: Starting Create swap on /dev/zram0...
Jan 18 14:42:35 machine zram-generator[868]: Error: Failed to configure disk size into /sys/block/zram0/disksize
Jan 18 14:42:35 machine zram-generator[868]: Caused by:
Jan 18 14:42:35 machine zram-generator[868]:     Device or resource busy (os error 16)
Jan 18 14:42:35 machine systemd[1]: systemd-zram-setup@zram0.service: Main process exited, code=exited, status=1/FAILURE
Jan 18 14:42:35 machine systemd[1]: systemd-zram-setup@zram0.service: Failed with result 'exit-code'.
Jan 18 14:42:35 machine systemd[1]: Failed to start Create swap on /dev/zram0.
```